### PR TITLE
feat: remove android permission we don't need

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.rnfs" >
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>


### PR DESCRIPTION
To avoid having to add an android permission for Android 11 we should remove the unused external storage write permission. https://exodusio.slack.com/archives/CFKF4FDTJ/p1594391595286800

We need to test (Android):
 - [x] the app works
 - [x] restore works
 - [x] localstorage works