### PR TITLE
perf: drop all deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,7 @@
   ],
   "author": "Johannes Lumpe <johannes@lum.pe> (https://github.com/johanneslumpe)",
   "license": "MIT",
-  "dependencies": {
-    "base-64": "^0.1.0",
-    "utf8": "^2.1.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "create-react-class": "15.6.3",
     "flow-bin": "0.78.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,11 +1080,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base-64@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
-  integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
-
 base64-js@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.1.2.tgz#d6400cac1c4c660976d90d07a04351d89395f5e8"
@@ -4734,11 +4729,6 @@ username@^3.0.0:
   dependencies:
     execa "^0.7.0"
     mem "^1.1.0"
-
-utf8@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/utf8/-/utf8-2.1.2.tgz#1fa0d9270e9be850d9b05027f63519bf46457d96"
-  integrity sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This could be further optimized by moving encoding param to native, as I already said -- there is no reason to convert base64 back and forth

But this PR should be trivial and could land first